### PR TITLE
Volume rendering shaders cleanup

### DIFF
--- a/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
+++ b/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
@@ -293,7 +293,7 @@ public class MultiVolumeShaderMip
 				"intersectBoundingBox", "vis", "SampleVolume", "Convert", "Accumulate" ) );
 		segments.put( SegmentType.AccumulatorMultiresolution, new SegmentTemplate(
 				"accumulate_mip_blocks.frag",
-				"vis", "sampleVolume", "convert" ) );
+				"vis", "sampleVolume", "convert", "renderType" ) );
 		segments.put( SegmentType.Accumulator, new SegmentTemplate(
 				"accumulate_mip_simple.frag",
 				"vis", "sampleVolume", "convert", "renderType" ) );

--- a/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
+++ b/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
@@ -249,12 +249,12 @@ public class MultiVolumeShaderMip
 		uniformTransform.set( new Matrix4f() );
 		uniformDsp.set( new Vector2f() );
 
-		final StringBuilder vertexShaderCode = prog.getVertexShaderCode();
-		System.out.println( "vertexShaderCode = " + vertexShaderCode );
-		System.out.println( "\n\n--------------------------------\n\n" );
-		final StringBuilder fragmentShaderCode = prog.getFragmentShaderCode();
-		System.out.println( "fragmentShaderCode = " + fragmentShaderCode );
-		System.out.println( "\n\n--------------------------------\n\n" );
+//		final StringBuilder vertexShaderCode = prog.getVertexShaderCode();
+//		System.out.println( "vertexShaderCode = " + vertexShaderCode );
+//		System.out.println( "\n\n--------------------------------\n\n" );
+//		final StringBuilder fragmentShaderCode = prog.getFragmentShaderCode();
+//		System.out.println( "fragmentShaderCode = " + fragmentShaderCode );
+//		System.out.println( "\n\n--------------------------------\n\n" );
 	}
 
 	public static Map< SegmentType, SegmentTemplate > getDefaultSegments( boolean useDepthTexture )

--- a/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
+++ b/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
@@ -281,10 +281,10 @@ public class MultiVolumeShaderMip
 				"volume", "sampleVolume" ) );
 		segments.put( SegmentType.Convert, new SegmentTemplate(
 				"convert.frag",
-				"convert", "offset", "scale", "gamma", "alphagamma","renderType","sizeLUT","lut", "zzz" ) );
+				"convert", "offset", "scale", "gamma", "alphagamma","renderType","sizeLUT","lut" ) );
 		segments.put( SegmentType.ConvertRGBA, new SegmentTemplate(
 				"convert_rgba.frag",
-				"convert", "offset", "scale", "gamma", "alphagamma" ) );
+				"convert", "offset", "scale", "gamma", "alphagamma", "renderType", "sizeLUT","lut" ) );
 		segments.put( SegmentType.MaxDepth, new SegmentTemplate(
 				useDepthTexture ? "maxdepthtexture.frag" : "maxdepthone.frag" ) );
 		segments.put( SegmentType.VertexShader, new SegmentTemplate( "multi_volume.vert" ) );

--- a/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
+++ b/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
@@ -207,6 +207,7 @@ public class MultiVolumeShaderMip
 			fp.bind( "vis", i, accumulate );
 			accumulate.bind( "sampleVolume", sampleVolume );
 			accumulate.bind( "convert", convert );
+			accumulate.bind( "renderType", convert );
 
 			sampleVolumeSegs[ i ] = sampleVolume;
 			convertSegs[ i ] = convert;
@@ -248,12 +249,12 @@ public class MultiVolumeShaderMip
 		uniformTransform.set( new Matrix4f() );
 		uniformDsp.set( new Vector2f() );
 
-//		final StringBuilder vertexShaderCode = prog.getVertexShaderCode();
-//		System.out.println( "vertexShaderCode = " + vertexShaderCode );
-//		System.out.println( "\n\n--------------------------------\n\n" );
-//		final StringBuilder fragmentShaderCode = prog.getFragmentShaderCode();
-//		System.out.println( "fragmentShaderCode = " + fragmentShaderCode );
-//		System.out.println( "\n\n--------------------------------\n\n" );
+		final StringBuilder vertexShaderCode = prog.getVertexShaderCode();
+		System.out.println( "vertexShaderCode = " + vertexShaderCode );
+		System.out.println( "\n\n--------------------------------\n\n" );
+		final StringBuilder fragmentShaderCode = prog.getFragmentShaderCode();
+		System.out.println( "fragmentShaderCode = " + fragmentShaderCode );
+		System.out.println( "\n\n--------------------------------\n\n" );
 	}
 
 	public static Map< SegmentType, SegmentTemplate > getDefaultSegments( boolean useDepthTexture )
@@ -295,7 +296,7 @@ public class MultiVolumeShaderMip
 				"vis", "sampleVolume", "convert" ) );
 		segments.put( SegmentType.Accumulator, new SegmentTemplate(
 				"accumulate_mip_simple.frag",
-				"vis", "sampleVolume", "convert" ) );
+				"vis", "sampleVolume", "convert", "renderType" ) );
 
 		return segments;
 	}

--- a/src/main/resources/bvvpg/core/render/accumulate_mip_blocks.frag
+++ b/src/main/resources/bvvpg/core/render/accumulate_mip_blocks.frag
@@ -1,6 +1,25 @@
 if (vis)
 {
 	float x = sampleVolume(wpos, volumeCache, cacheSize, blockSize, paddedBlockSize, cachePadOffset);
-	//v = max(v, convert(x));
-	v = convert(v, x);
+
+	vnew = convert(x);	
+	
+	//max projection
+	if(renderType == 0)
+	{	
+		v =  max(vnew, v);
+	}
+	
+	//volumetric
+	if(renderType == 1)
+	{
+		v = v + (1.-v.a) * vec4( vnew.rgb, 1 ) *vnew.a;		 
+	}
+	
+	//min projection
+	if(renderType == 2)
+	{
+		v = min(v, vnew);
+	}
+
 }

--- a/src/main/resources/bvvpg/core/render/accumulate_mip_simple.frag
+++ b/src/main/resources/bvvpg/core/render/accumulate_mip_simple.frag
@@ -1,8 +1,8 @@
 if (vis)
 {
-	//v = max(v, convert(sampleVolume(wpos)));
-	
-	vnew = convert(sampleVolume(wpos));	
+	float x = sampleVolume(wpos);
+
+	vnew = convert(x);	
 	
 	//max projection
 	if(renderType == 0)

--- a/src/main/resources/bvvpg/core/render/accumulate_mip_simple.frag
+++ b/src/main/resources/bvvpg/core/render/accumulate_mip_simple.frag
@@ -1,5 +1,25 @@
 if (vis)
 {
 	//v = max(v, convert(sampleVolume(wpos)));
-	v = convert(v, sampleVolume(wpos));
+	
+	vnew = convert(sampleVolume(wpos));	
+	
+	//max projection
+	if(renderType == 0)
+	{	
+		v =  max(vnew, v);
+	}
+	
+	//volumetric
+	if(renderType == 1)
+	{
+		v = v + (1.-v.a) * vec4( vnew.rgb, 1 ) *vnew.a;		 
+	}
+	
+	//min projection
+	if(renderType == 2)
+	{
+		v = min(v, vnew);
+	}
+
 }

--- a/src/main/resources/bvvpg/core/render/accumulate_mip_simple.frag
+++ b/src/main/resources/bvvpg/core/render/accumulate_mip_simple.frag
@@ -1,8 +1,6 @@
 if (vis)
 {
-	float x = sampleVolume(wpos);
-
-	vnew = convert(x);	
+	vnew = convert(sampleVolume(wpos));	
 	
 	//max projection
 	if(renderType == 0)

--- a/src/main/resources/bvvpg/core/render/convert.frag
+++ b/src/main/resources/bvvpg/core/render/convert.frag
@@ -6,7 +6,7 @@ uniform int renderType;
 uniform int sizeLUT;
 uniform sampler3D lut;
 
-vec4 convert(float v )
+vec4 convert(float v)
 {
 	vec4 finC = vec4(0);
 	

--- a/src/main/resources/bvvpg/core/render/convert.frag
+++ b/src/main/resources/bvvpg/core/render/convert.frag
@@ -6,7 +6,7 @@ uniform int renderType;
 uniform int sizeLUT;
 uniform sampler3D lut;
 
-vec4 convert(vec4 acc, float v )
+vec4 convert(float v )
 {
 	vec4 finC = vec4(0);
 	
@@ -29,6 +29,7 @@ vec4 convert(vec4 acc, float v )
 		//q.x = pow(clamp(offset.r + scale.r * v,0.0,1.0),gamma);
 				
 		finC =  texture( lut, q);
+		
 		finC.a = finC.a*pow(clamp(offset.a + scale.a * v,0.0,1.0),alphagamma);	
 	}
 	else
@@ -39,25 +40,6 @@ vec4 convert(vec4 acc, float v )
 		finC.a = pow(clamp(offset.a + scale.a * v,0.0,1.0),alphagamma);			
 	}
 	
-		
-	
-	//max projection
-	if(renderType==0)
-	{	
-		return max(acc, finC);
-	}
-	
-	//volumetric
-	if(renderType==1)
-	{
-		finC = acc + (1.-acc.a) * vec4( finC.rgb, 1 ) *finC.a;		 
-		return finC;
-
-	}
-	//min projection
-	else
-	{
-		return min(acc, finC);
-	}
-	
+	return finC;
 }
+		

--- a/src/main/resources/bvvpg/core/render/convert_rgba.frag
+++ b/src/main/resources/bvvpg/core/render/convert_rgba.frag
@@ -3,31 +3,21 @@ uniform vec4 scale;
 uniform float gamma;
 uniform float alphagamma;
 uniform int renderType;
+uniform int sizeLUT;
+uniform sampler3D lut;
 
 
-vec4 convert(vec4 acc, vec4 v )
+vec4 convert(vec4 v )
 {
 	vec4 finC = vec4(0);
 	
 	float al = (v.r+v.g+v.b)/3.0;
 	finC.a = pow(clamp(offset.a + scale.a * al,0.0,1.0),alphagamma);			
-	finC.r= pow(clamp(offset.r + scale.r * v.r,0.0,1.0),gamma);
-	finC.g= pow(clamp(offset.g + scale.g * v.g,0.0,1.0),gamma);
-	finC.b= pow(clamp(offset.b + scale.b * v.b,0.0,1.0),gamma);
+	finC.r = pow(clamp(offset.r + scale.r * v.r,0.0,1.0),gamma);
+	finC.g = pow(clamp(offset.g + scale.g * v.g,0.0,1.0),gamma);
+	finC.b = pow(clamp(offset.b + scale.b * v.b,0.0,1.0),gamma);
 	
-
-	
-	if(renderType==0)
-	{	
-		//need to think about it, if it is true
-		return max(acc, finC);
-	}
-	else
-	{
-		finC = acc + (1.-acc.a) * vec4( finC.rgb, 1 ) *finC.a;		 
-		return finC;
-
-	}
-	
+	return finC;
+		
 }
 

--- a/src/main/resources/bvvpg/core/render/multi_volume.frag
+++ b/src/main/resources/bvvpg/core/render/multi_volume.frag
@@ -83,6 +83,7 @@ void main()
 
 		float step = tnear;
 		vec4 v = vec4(0);
+		vec4 vnew = vec4(0);
 		for (int i = 0; i < numSteps; ++i, step += nw + step * fwnw)
 		{
 			vec4 wpos = mix(wfront, wback, step);
@@ -99,8 +100,8 @@ void main()
 			*/
 			if(v.a>0.99)
 			{
-				v.a=1.0;
-				i=numSteps;
+				v.a = 1.0;
+				i = numSteps;
 			}
 		}
 		FragColor = v;

--- a/src/test/java/bvv/vistools/examples/PG_Example01.java
+++ b/src/test/java/bvv/vistools/examples/PG_Example01.java
@@ -33,9 +33,7 @@ import java.util.List;
 import bdv.spimdata.SpimDataMinimal;
 import bdv.spimdata.XmlIoSpimDataMinimal;
 
-import bvvpg.vistools.Bvv;
 import bvvpg.vistools.BvvFunctions;
-import bvvpg.vistools.BvvOptions;
 import bvvpg.vistools.BvvSource;
 import bvvpg.vistools.BvvStackSource;
 import ij.IJ;
@@ -46,9 +44,7 @@ import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.display.imagej.ImageJFunctions;
-
 import net.imglib2.type.numeric.integer.UnsignedShortType;
-
 
 
 public class PG_Example01 {
@@ -84,6 +80,8 @@ public class PG_Example01 {
 		final BvvSource source = sources.get(0);
 		double [] minI = spimData.getSequenceDescription().getImgLoader().getSetupImgLoader(0).getImage(0).minAsDoubleArray();
 		double [] maxI = spimData.getSequenceDescription().getImgLoader().getSetupImgLoader(0).getImage(0).maxAsDoubleArray();
+		
+		//scale clipping interval
 		VoxelDimensions voxSize = spimData.getSequenceDescription().getViewSetupsOrdered().get( 0 ).getVoxelSize();
 		for(int d=0; d<3; d++)
 		{
@@ -121,8 +119,7 @@ public class PG_Example01 {
 		//source.setLUT( icm_lut, "SpectrumLUT" );
 
 		
-		//clip half of the volume along Z axis in the shaders
-		//clipInterval is defined inside the "raw", non-transformed data interval		
+		//clip half of the volume along Z axis in the shaders	
 		minI[2]=0.5*maxI[2];		
 		source.setClipInterval(new FinalRealInterval(minI,maxI));		
 		

--- a/src/test/java/bvv/vistools/examples/PG_Example01.java
+++ b/src/test/java/bvv/vistools/examples/PG_Example01.java
@@ -41,6 +41,8 @@ import bvvpg.vistools.BvvStackSource;
 import ij.IJ;
 import ij.ImagePlus;
 import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+
 import net.imglib2.FinalRealInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.display.imagej.ImageJFunctions;
@@ -48,10 +50,12 @@ import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 
 
+
 public class PG_Example01 {
 	
 	/**
-	 * Show 16-bit volume, change rendering type and gamma
+	 * Show 16-bit volume, change display range, change gamma,
+	 * rendering type, alpha value, apply LUT and clip volume in half
 	 */
 	public static void main( final String[] args )
 	{
@@ -69,7 +73,7 @@ public class PG_Example01 {
 
 		//BDV XML init (multiscale cached)
 		/*
-		final String xmlFilename = "/home/eugene/Desktop/projects/BigTrace/BigTrace_data/head_2ch.xml";
+		final String xmlFilename = "/home/eugene/Desktop/projects/BigTrace/BigTrace_data/t1-head.xml";
 		SpimDataMinimal spimData = null;
 		try {
 			spimData = new XmlIoSpimDataMinimal().load( xmlFilename );
@@ -80,6 +84,13 @@ public class PG_Example01 {
 		final BvvSource source = sources.get(0);
 		double [] minI = spimData.getSequenceDescription().getImgLoader().getSetupImgLoader(0).getImage(0).minAsDoubleArray();
 		double [] maxI = spimData.getSequenceDescription().getImgLoader().getSetupImgLoader(0).getImage(0).maxAsDoubleArray();
+		VoxelDimensions voxSize = spimData.getSequenceDescription().getViewSetupsOrdered().get( 0 ).getVoxelSize();
+		for(int d=0; d<3; d++)
+		{
+			minI[d] *= voxSize.dimension( d );
+			maxI[d] *= voxSize.dimension( d );
+
+		}
 		*/
 	
 		source.setDisplayRangeBounds( 0, 40000 );

--- a/src/test/java/bvv/vistools/examples/PG_Example02.java
+++ b/src/test/java/bvv/vistools/examples/PG_Example02.java
@@ -42,10 +42,10 @@ import bvvpg.vistools.Bvv;
 import bvvpg.vistools.BvvFunctions;
 import bvvpg.vistools.BvvSource;
 
-/** show difference in the source (volume) interpolation **/
-
 public class PG_Example02
 {
+	/** Show difference in the source (volume) interpolation **/
+
 	public static void main( final String[] args )
 	{
 		int nRadius = 35;
@@ -56,10 +56,13 @@ public class PG_Example02
 		center.setPosition( nRadius+1 , 0 );
 		center.setPosition( nRadius+1 , 1 );
 		center.setPosition( nRadius+1 , 2 );
+		
 		ArrayImg< UnsignedShortType, ShortArray > sphereRai = ArrayImgs.unsignedShorts(dim);
 		HyperSphere< UnsignedShortType > hyperSphere =
 				new HyperSphere<>( sphereRai, center, nRadius);			
+		
 		HyperSphereCursor< UnsignedShortType > cursor = hyperSphere.localizingCursor();
+		
 		while ( cursor.hasNext() )
 		{
 			cursor.fwd();
@@ -81,6 +84,7 @@ public class PG_Example02
 		source2.setDisplayRangeBounds( 0, 255 );
 		source2.setRenderType( 1 );
 		source2.setAlphaRangeBounds( 0, 255 );
+		
 		//set source as no interpolation
 		source2.setVoxelRenderInterpolation( 0 );
 		source2.setLUT( "Spectrum" );

--- a/src/test/java/bvvpg/debug/DebugRGBSource.java
+++ b/src/test/java/bvvpg/debug/DebugRGBSource.java
@@ -1,0 +1,25 @@
+package bvvpg.debug;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.ARGBType;
+
+import bvvpg.vistools.Bvv;
+import bvvpg.vistools.BvvFunctions;
+import bvvpg.vistools.BvvStackSource;
+import ij.IJ;
+import ij.ImagePlus;
+
+public class DebugRGBSource
+{
+	/**
+	 * Test rendering of RGB volume (shaders)
+	 */
+	public static void main( final String[] args )
+	{
+		final ImagePlus imp = IJ.openImage( "/home/eugene/Desktop/projects/BigTrace/BigTrace_data/RGB/ExM_MT.tif" );
+		final RandomAccessibleInterval< ARGBType > rgbRAI = ImageJFunctions.wrapRGBA( imp );
+		final BvvStackSource< ? > sourceRGB = BvvFunctions.show( rgbRAI,
+				"rgbVolume" );
+	}
+}

--- a/src/test/java/bvvpg/debug/DebugRenderStatus.java
+++ b/src/test/java/bvvpg/debug/DebugRenderStatus.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package bvv.vistools.examples;
+package bvvpg.debug;
 
 import java.util.List;
 
@@ -36,7 +36,7 @@ import bvvpg.vistools.BvvFunctions;
 import bvvpg.vistools.BvvStackSource;
 import mpicbg.spim.data.SpimDataException;
 
-public class PG_RenderFrame
+public class DebugRenderStatus
 {
 	public static void main( final String[] args )
 	{


### PR DESCRIPTION
- moved `renderType` from `convert` to accumulate `shader`;
- corrected rendering of "simple" RGB volumes;
- multiple minor fixes;
- cleaned up examples a bit.