### PR TITLE
major update and reworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This is a fork of [BVV](https://github.com/bigdataviewer/bigvolumeviewer-core) w
 - "volumetric" rendering method ("alpha-blending");
 - nearest-neighbor and trilinear interpolation;
 - lookup tables (LUTs, custom with alpha values and coming from ImageJ);
-- clipping of displayed sources in shaders (optionally using custom transform).
+- clipping of displayed sources in shaders (optionally using custom transform);
+- perspective and orthographic projections.
 
 Currently synced to BVV version 0.3.4 (this [commit](https://github.com/bigdataviewer/bigvolumeviewer-core/tree/2b8367ef592ede840ecba932deb7ff19b1896d6a)).
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ and add the corresponding dependency:
 
 You need to download and ship the latest _bvv-playground-X.X.X.jar_ from [maven](https://maven.scijava.org/#nexus-search;quick~bvv-playground) or [release](https://github.com/UU-cellbiology/bvv-playground/releases). 
 
+## Updates history
+
+It is available through releases description or [as one file](https://github.com/UU-cellbiology/bvv-playground/blob/master/updates_history.md).
 
 ----------
 Developed in <a href='http://cellbiology.science.uu.nl/'>Cell Biology group</a> of Utrecht University.  

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>nl.uu.science.cellbiology</groupId>
 	<artifactId>bvv-playground</artifactId>
-	<version>0.3.5-SNAPSHOT</version>
+	<version>0.4.0-SNAPSHOT</version>
 
 	<name>BVV-playground</name>
 	<description>Volume rendering of bdv datasets with gamma and transparency option</description>

--- a/pom.xml
+++ b/pom.xml
@@ -191,11 +191,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>nl.uu.science.cellbiology</groupId>
-			<artifactId>AveragingND</artifactId>
-			<version>0.1.1-SNAPSHOT</version>
-		</dependency>
 	</dependencies>
 	
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>nl.uu.science.cellbiology</groupId>
+			<artifactId>AveragingND</artifactId>
+			<version>0.1.1-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 	
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<license.copyrightOwners>Cell Biology, Neurobiology and Biophysics Department of Utrecht University.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
-		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles> 
+		<!-- releaseProfiles sign,deploy-to-scijava releaseProfiles --> 
 	</properties>
 
 	<dependencies>

--- a/src/main/java/bvvpg/core/VolumeViewerPanel.java
+++ b/src/main/java/bvvpg/core/VolumeViewerPanel.java
@@ -65,6 +65,7 @@ import bvvpg.core.render.RenderData;
 import bvvpg.core.render.VolumeRenderer;
 import bvvpg.core.render.VolumeRenderer.RepaintType;
 import bvvpg.core.util.MatrixMath;
+import bvvpg.pgcards.sourcetable.SourceSelectionState;
 import bvvpg.source.converters.ConverterSetupsPG;
 
 import com.jogamp.opengl.GL3;
@@ -167,6 +168,9 @@ public class VolumeViewerPanel
 	private boolean bRenderMode = false;
 
 	private final Repaint repaint = new Repaint();
+	
+	public SourceSelectionState sourceSelection;
+	public SourceSelectionState sourceGroupSelection;
 
 	protected final OffScreenFrameBufferWithDepth sceneBuf;
 
@@ -1137,4 +1141,6 @@ public class VolumeViewerPanel
 		}
 		state.kill();
 	}
+	
+	
 }

--- a/src/main/java/bvvpg/core/VolumeViewerPanel.java
+++ b/src/main/java/bvvpg/core/VolumeViewerPanel.java
@@ -66,6 +66,7 @@ import bvvpg.core.render.VolumeRenderer;
 import bvvpg.core.render.VolumeRenderer.RepaintType;
 import bvvpg.core.util.MatrixMath;
 import bvvpg.pgcards.sourcetable.SourceSelectionState;
+import bvvpg.pgcards.sourcetable.SourceSelectionWindowState;
 import bvvpg.source.converters.ConverterSetupsPG;
 
 import com.jogamp.opengl.GL3;
@@ -171,6 +172,7 @@ public class VolumeViewerPanel
 	
 	public SourceSelectionState sourceSelection;
 	public SourceSelectionState sourceGroupSelection;
+	public SourceSelectionWindowState sourceSelectionWindowState;
 
 	protected final OffScreenFrameBufferWithDepth sceneBuf;
 

--- a/src/main/java/bvvpg/core/VolumeViewerPanel.java
+++ b/src/main/java/bvvpg/core/VolumeViewerPanel.java
@@ -166,7 +166,13 @@ public class VolumeViewerPanel
 		}
 	}
 	
+	/** activates "rendering mode", 
+	 * changing repaint style update mode **/
 	private boolean bRenderMode = false;
+	
+	/** screen projection method,
+	 * 0 - perspective, 1 - orthographic **/
+	private int nProjectionType = 0;
 
 	private final Repaint repaint = new Repaint();
 	
@@ -419,7 +425,32 @@ public class VolumeViewerPanel
 		return bRenderMode;
 	}
 	
-
+	/** screen projection method,
+	 * 0 - perspective, 1 - orthographic **/
+	public int getProjectionType ()
+	{
+		return nProjectionType;
+	}
+	
+	/** screen projection method,
+	 * 0 - perspective, 1 - orthographic **/
+	public void setProjectionType (final int nProjectionType)
+	{
+		int newProj = nProjectionType;
+		if(nProjectionType != 0)
+		{
+			newProj = 1;
+		}
+		else
+		{
+			newProj = 0;
+		}
+		if(newProj != this.nProjectionType)
+		{
+			this.nProjectionType = newProj;
+			requestRepaint();
+		}
+	}
 	/**
 	 * @deprecated Modify {@link #state()} directly
 	 */
@@ -994,7 +1025,7 @@ public class VolumeViewerPanel
 			final AffineTransform3D renderTransformWorldToScreen = state.getViewerTransform();
 
 			final Matrix4f view = MatrixMath.affine( renderTransformWorldToScreen, new Matrix4f() );
-			MatrixMath.screenPerspective( dCam, dClipNear, dClipFar, screenWidth, screenHeight, 0, pv ).mul( view );
+			MatrixMath.screenPerspective( nProjectionType, dCam, dClipNear, dClipFar, screenWidth, screenHeight, 0, pv ).mul( view );
 
 			renderStacks.clear();
 			renderConverters.clear();

--- a/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
+++ b/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
@@ -56,6 +56,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.ARGBType;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
@@ -594,8 +595,10 @@ public class MultiVolumeShaderMip
 				{
 					uniformClipActive.set(1);
 					uniformClipMin.set(gconverter.getClipInterval(),bvvpg.core.shadergen.MinMax.MIN);
-					uniformClipMax.set(gconverter.getClipInterval(),bvvpg.core.shadergen.MinMax.MAX);				
-					uniformClipTransform.set(MatrixMath.affine(gconverter.getClipTransform(), new Matrix4f()));
+					uniformClipMax.set(gconverter.getClipInterval(),bvvpg.core.shadergen.MinMax.MAX);	
+					final AffineTransform3D t = new AffineTransform3D();
+					gconverter.getClipTransform(t);
+					uniformClipTransform.set(MatrixMath.affine(t, new Matrix4f()));
 				}
 				uniformLUT.set(((GammaConverterSetup) converter).getLUTTexture());
 			}

--- a/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
+++ b/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
@@ -598,6 +598,7 @@ public class MultiVolumeShaderMip
 					uniformClipMax.set(gconverter.getClipInterval(),bvvpg.core.shadergen.MinMax.MAX);	
 					final AffineTransform3D t = new AffineTransform3D();
 					gconverter.getClipTransform(t);
+					//t.set(t.inverse());
 					uniformClipTransform.set(MatrixMath.affine(t, new Matrix4f()));
 				}
 				uniformLUT.set(((GammaConverterSetup) converter).getLUTTexture());

--- a/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
+++ b/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
@@ -598,7 +598,7 @@ public class MultiVolumeShaderMip
 					uniformClipMax.set(gconverter.getClipInterval(),bvvpg.core.shadergen.MinMax.MAX);	
 					final AffineTransform3D t = new AffineTransform3D();
 					gconverter.getClipTransform(t);
-					//t.set(t.inverse());
+					t.set(t.inverse());
 					uniformClipTransform.set(MatrixMath.affine(t, new Matrix4f()));
 				}
 				uniformLUT.set(((GammaConverterSetup) converter).getLUTTexture());

--- a/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
+++ b/src/main/java/bvvpg/core/render/MultiVolumeShaderMip.java
@@ -590,7 +590,7 @@ public class MultiVolumeShaderMip
 				uniformVoxelInterpolation.set(gconverter.getVoxelRenderInterpolation());
 				fminA = gconverter.getAlphaRangeMin() / rangeScale;
 				fmaxA = gconverter.getAlphaRangeMax() / rangeScale;
-				if(gconverter.clipActive())
+				if(gconverter.clipActive() && gconverter.getClipInterval() != null)
 				{
 					uniformClipActive.set(1);
 					uniformClipMin.set(gconverter.getClipInterval(),bvvpg.core.shadergen.MinMax.MIN);

--- a/src/main/java/bvvpg/core/util/MatrixMath.java
+++ b/src/main/java/bvvpg/core/util/MatrixMath.java
@@ -61,9 +61,9 @@ public class MatrixMath
 	 * @param screenPadding additional padding on all sides of the screen plane
 	 * @param matrix is set to the screenPerspective transformation and returned
 	 */
-	public static Matrix4f screenPerspective( double dCam, final double dClip, final double screenWidth, final double screenHeight, final double screenPadding, Matrix4f matrix )
+	public static Matrix4f screenPerspective( final int nProjectionType, double dCam, final double dClip, final double screenWidth, final double screenHeight, final double screenPadding, Matrix4f matrix )
 	{
-		return screenPerspective( dCam, dClip, dClip, screenWidth, screenHeight, screenPadding, matrix );
+		return screenPerspective(nProjectionType, dCam, dClip, dClip, screenWidth, screenHeight, screenPadding, matrix );
 	}
 
 	/**
@@ -77,7 +77,7 @@ public class MatrixMath
 	 * @param screenPadding additional padding on all sides of the screen plane
 	 * @param matrix is set to the screenPerspective transformation and returned
 	 */
-	public static Matrix4f screenPerspective( double dCam, final double dClipNear, final double dClipFar, final double screenWidth, final double screenHeight, final double screenPadding, Matrix4f matrix )
+	public static Matrix4f screenPerspective(final int nProjectionType, double dCam, final double dClipNear, final double dClipFar, final double screenWidth, final double screenHeight, final double screenPadding, Matrix4f matrix )
 	{
 		double r0 = ( screenWidth + screenPadding ) / 2;
 		double t0 = ( screenHeight + screenPadding ) / 2;
@@ -90,10 +90,20 @@ public class MatrixMath
 		float n = ( float ) ( dCam - dClipNear );
 		float f = ( float ) ( dCam + dClipFar );
 
+		if( nProjectionType == 0)
+		{
+			matrix
+			.setFrustum( l, r, b, t, n, f );
+		}
+		else
+		{	
+			matrix
+			.setOrtho( l, r, b, t, n, f );		
+		}
 		matrix
-				.setFrustum( l, r, b, t, n, f )
-				.scale( 1f, -1f, -1f )
-				.translate( ( float ) ( -( screenWidth - 1 ) / 2 ), ( float ) ( -( screenHeight - 1 ) / 2 ), ( float ) dCam );
+		.scale( 1f, -1f, -1f )
+		.translate( ( float ) ( -( screenWidth - 1 ) / 2 ), ( float ) ( -( screenHeight - 1 ) / 2 ), ( float ) dCam );
+
 		return matrix;
 
 		// frustum by hand...
@@ -157,7 +167,7 @@ public class MatrixMath
 	 * @param matrix
 	 * 		is set to the screenPerspective transformation and returned
 	 */
-	public static Matrix4f perspective( double dCam, final double dClipNear, final double dClipFar, final double screenWidth, final double screenHeight, final double screenPadding, Matrix4f matrix )
+	public static Matrix4f perspective( final int nProjectionType, double dCam, final double dClipNear, final double dClipFar, final double screenWidth, final double screenHeight, final double screenPadding, Matrix4f matrix )
 	{
 		double r0 = ( screenWidth + screenPadding ) / 2;
 		double t0 = ( screenHeight + screenPadding ) / 2;
@@ -169,9 +179,18 @@ public class MatrixMath
 		float l = -r;
 		float n = ( float ) ( dCam - dClipNear );
 		float f = ( float ) ( dCam + dClipFar );
-
+		
+		if( nProjectionType == 0)
+		{
+			matrix
+			.setFrustum( l, r, b, t, n, f );
+		}
+		else
+		{	
+			matrix
+			.setOrtho( l, r, b, t, n, f );		
+		}
 		matrix
-				.setFrustum( l, r, b, t, n, f )
 				.scale( 1f, -1f, -1f );
 		return matrix;
 	}

--- a/src/main/java/bvvpg/pgcards/BVVPGDefaultCards.java
+++ b/src/main/java/bvvpg/pgcards/BVVPGDefaultCards.java
@@ -46,6 +46,7 @@ import bdv.viewer.AbstractViewerPanel;
 import bdv.viewer.ViewerState;
 import bvvpg.core.VolumeViewerPanel;
 import bvvpg.pgcards.sourcetable.SourceSelectionState;
+import bvvpg.pgcards.sourcetable.SourceSelectionWindowState;
 import bvvpg.pgcards.sourcetable.SourceTablePG;
 import bvvpg.source.converters.ConverterSetupsPG;
 import bvvpg.ui.panels.ConverterSetupEditPanelPG;
@@ -102,6 +103,7 @@ public class BVVPGDefaultCards
 		{
 			((VolumeViewerPanel)viewer).sourceSelection = new SourceSelectionState(table);
 			((VolumeViewerPanel)viewer).sourceGroupSelection = new SourceSelectionState(tree, converterSetups);
+			((VolumeViewerPanel)viewer).sourceSelectionWindowState = new SourceSelectionWindowState(table, tree, converterSetups);
 		}
 
 		cards.addCard( DEFAULT_VIEWERMODES_CARD, "Display Modes", new DisplaySettingsPanel( viewer.state() ), true, new Insets( 0, 4, 4, 0 ) );

--- a/src/main/java/bvvpg/pgcards/BVVPGDefaultCards.java
+++ b/src/main/java/bvvpg/pgcards/BVVPGDefaultCards.java
@@ -44,6 +44,8 @@ import bdv.ui.sourcegrouptree.SourceGroupTree;
 import bdv.ui.viewermodepanel.DisplaySettingsPanel;
 import bdv.viewer.AbstractViewerPanel;
 import bdv.viewer.ViewerState;
+import bvvpg.core.VolumeViewerPanel;
+import bvvpg.pgcards.sourcetable.SourceSelectionState;
 import bvvpg.pgcards.sourcetable.SourceTablePG;
 import bvvpg.source.converters.ConverterSetupsPG;
 import bvvpg.ui.panels.ConverterSetupEditPanelPG;
@@ -60,8 +62,10 @@ public class BVVPGDefaultCards
 	{
 		final ViewerState state = viewer.state();
 
+
 		// -- Sources table --
 		final SourceTablePG table = new SourceTablePG( state, converterSetups, viewer.getInputTriggerConfig() );
+		
 		table.setPreferredScrollableViewportSize( new Dimension( 340, 200 ) );
 		table.setFillsViewportHeight( true );
 		table.setDragEnabled( true );
@@ -92,6 +96,13 @@ public class BVVPGDefaultCards
 		treePanel.add( scrollPaneTree, BorderLayout.CENTER );
 		treePanel.add( editPanelTree, BorderLayout.SOUTH );
 		treePanel.setPreferredSize( new Dimension( 340, 225 ) );
+		
+		//add external listeners to sources selection
+		if(viewer instanceof VolumeViewerPanel)
+		{
+			((VolumeViewerPanel)viewer).sourceSelection = new SourceSelectionState(table);
+			((VolumeViewerPanel)viewer).sourceGroupSelection = new SourceSelectionState(tree, converterSetups);
+		}
 
 		cards.addCard( DEFAULT_VIEWERMODES_CARD, "Display Modes", new DisplaySettingsPanel( viewer.state() ), true, new Insets( 0, 4, 4, 0 ) );
 		cards.addCard( DEFAULT_SOURCES_CARD, "Sources", tablePanel, true, new Insets( 0, 0, 0, 0 ) );

--- a/src/main/java/bvvpg/pgcards/sourcetable/SourceSelectionState.java
+++ b/src/main/java/bvvpg/pgcards/sourcetable/SourceSelectionState.java
@@ -22,7 +22,7 @@ public class SourceSelectionState
 		public void selectionCSChanged(List< ConverterSetup > csList);
 
 	}
-	public SourceSelectionState( final SourceTablePG table)
+	public SourceSelectionState(final SourceTablePG table)
 	{
 		this( table::getSelectedConverterSetups);
 		table.getSelectionModel().addListSelectionListener( e -> updateSelection() );

--- a/src/main/java/bvvpg/pgcards/sourcetable/SourceSelectionState.java
+++ b/src/main/java/bvvpg/pgcards/sourcetable/SourceSelectionState.java
@@ -17,6 +17,8 @@ public class SourceSelectionState
 
 	private ArrayList<Listener> listeners =	new ArrayList<>();
 	
+	public SourceTablePG table = null;
+	
 	public static interface Listener 
 	{
 		public void selectionCSChanged(List< ConverterSetup > csList);
@@ -26,6 +28,7 @@ public class SourceSelectionState
 	{
 		this( table::getSelectedConverterSetups);
 		table.getSelectionModel().addListSelectionListener( e -> updateSelection() );
+		this.table = table;
 	}
 	public SourceSelectionState( final SourceGroupTree tree, final ConverterSetupsPG converterSetups)
 	{

--- a/src/main/java/bvvpg/pgcards/sourcetable/SourceSelectionState.java
+++ b/src/main/java/bvvpg/pgcards/sourcetable/SourceSelectionState.java
@@ -1,0 +1,74 @@
+package bvvpg.pgcards.sourcetable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
+
+import bdv.tools.brightness.ConverterSetup;
+import bdv.ui.sourcegrouptree.SourceGroupTree;
+import bvvpg.source.converters.ConverterSetupsPG;
+
+public class SourceSelectionState
+{
+	private final Supplier< List< ConverterSetup > > selectedConverterSetups;
+
+	private ArrayList<Listener> listeners =	new ArrayList<>();
+	
+	public static interface Listener 
+	{
+		public void selectionCSChanged(List< ConverterSetup > csList);
+
+	}
+	public SourceSelectionState( final SourceTablePG table)
+	{
+		this( table::getSelectedConverterSetups);
+		table.getSelectionModel().addListSelectionListener( e -> updateSelection() );
+	}
+	public SourceSelectionState( final SourceGroupTree tree, final ConverterSetupsPG converterSetups)
+	{
+		this(() -> converterSetups.getConverterSetups( tree.getSelectedSources() ));
+		tree.getSelectionModel().addTreeSelectionListener( e -> updateSelection() );
+		tree.getModel().addTreeModelListener( new TreeModelListener()
+		{
+			@Override
+			public void treeNodesChanged( final TreeModelEvent e )
+			{
+				updateSelection();
+			}
+
+			@Override
+			public void treeNodesInserted( final TreeModelEvent e )
+			{
+				updateSelection();
+			}
+
+			@Override
+			public void treeNodesRemoved( final TreeModelEvent e )
+			{
+				updateSelection();
+			}
+
+			@Override
+			public void treeStructureChanged( final TreeModelEvent e )
+			{
+				updateSelection();
+			}
+		} );
+	}
+	private SourceSelectionState(final Supplier< List< ConverterSetup > > selectedConverterSetups)
+	{
+		this.selectedConverterSetups = selectedConverterSetups;
+	}
+	public synchronized void updateSelection()
+	{
+		for(Listener l : listeners)
+			l.selectionCSChanged(selectedConverterSetups.get());
+	}
+	public void addSourceSelectionStateListener(Listener l) 
+	{
+        listeners.add(l);
+    }
+}

--- a/src/main/java/bvvpg/pgcards/sourcetable/SourceSelectionWindowState.java
+++ b/src/main/java/bvvpg/pgcards/sourcetable/SourceSelectionWindowState.java
@@ -1,0 +1,59 @@
+package bvvpg.pgcards.sourcetable;
+
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.util.ArrayList;
+import java.util.List;
+
+import bdv.tools.brightness.ConverterSetup;
+import bdv.ui.sourcegrouptree.SourceGroupTree;
+import bvvpg.source.converters.ConverterSetupsPG;
+
+public class SourceSelectionWindowState implements FocusListener
+{
+	private ArrayList<Listener> listeners =	new ArrayList<>();
+	
+	final SourceTablePG table;
+	final SourceGroupTree tree; 
+	final ConverterSetupsPG convSetups;
+	public static interface Listener 
+	{
+		public void selectionWindowChanged(int nWindow, List< ConverterSetup > csList);
+
+	}
+	public SourceSelectionWindowState(final SourceTablePG table, final SourceGroupTree tree, final ConverterSetupsPG converterSetups)
+	{
+		this.table = table;
+		this.tree = tree;
+		this.convSetups = converterSetups;
+		
+		table.addFocusListener( this );
+		tree.addFocusListener( this );
+	}
+	@Override
+	public void focusGained( FocusEvent e )
+	{
+		e.getSource();
+		if(e.getSource() == table)
+		{
+			for(Listener l : listeners)
+				l.selectionWindowChanged(0, table.getSelectedConverterSetups());
+		}
+		else
+		{
+			for(Listener l : listeners)
+				l.selectionWindowChanged(1,  convSetups.getConverterSetups( tree.getSelectedSources() ));			
+		}
+		
+	}
+	@Override
+	public void focusLost( FocusEvent e )
+	{
+		
+		
+	}
+	public void addSourceSelectionWindowStateListener(Listener l) 
+	{
+        listeners.add(l);
+    }
+}

--- a/src/main/java/bvvpg/pgcards/sourcetable/SourceTableModelPG.java
+++ b/src/main/java/bvvpg/pgcards/sourcetable/SourceTableModelPG.java
@@ -57,7 +57,7 @@ public class SourceTableModelPG extends AbstractTableModel
 
 	private final SourceToConverterSetupBimap converters;
 
-	private StateModel model;
+	public StateModel model;
 
 	public static final int NAME_COLUMN = 0;
 	public static final int IS_CURRENT_COLUMN = 1;

--- a/src/main/java/bvvpg/pgcards/sourcetable/SourceTablePG.java
+++ b/src/main/java/bvvpg/pgcards/sourcetable/SourceTablePG.java
@@ -35,6 +35,7 @@ import bdv.viewer.ConverterSetups;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.SourceToConverterSetupBimap;
 import bdv.viewer.ViewerState;
+import bvvpg.pgcards.sourcetable.SourceTableModelPG.SourceModel;
 import bvvpg.source.converters.GammaConverterSetup;
 import ij.IJ;
 
@@ -166,6 +167,28 @@ public class SourceTablePG extends JTable
 		for ( final int row : getSelectedRows() )
 			sources.add( model.getValueAt( row ).getSource() );
 		return sources;
+	}
+	
+	public void setSelectedSources(List< SourceAndConverter< ? > > sacList)
+	{
+		ArrayList<Integer> selectedIndices = new ArrayList<>();
+		for(SourceAndConverter< ? > sac:sacList)
+		{		
+				int nIndex = model.model.getSources().indexOf( new SourceModel(sac,state) );
+				selectedIndices.add( new Integer (nIndex ));
+		}
+		for(int i=0;i<selectedIndices.size(); i++)
+		{
+			if(i==0)
+			{
+				this.setRowSelectionInterval( selectedIndices.get( i ).intValue(), selectedIndices.get( i ).intValue() );
+			}
+			else
+			{
+				this.getSelectionModel().addSelectionInterval( selectedIndices.get( i ).intValue(), selectedIndices.get( i ).intValue() );				
+			}
+		}
+		
 	}
 
 	public List< ConverterSetup > getSelectedConverterSetups()

--- a/src/main/java/bvvpg/source/converters/GammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/GammaConverterSetup.java
@@ -78,6 +78,8 @@ public interface GammaConverterSetup extends ConverterSetup {
 	
 	void setClipInterval(RealInterval clipInt);
 	
+	void setClipActive(boolean bEnabled);
+	
 	FinalRealInterval getClipInterval();
 	
 	AffineTransform3D getClipTransform();

--- a/src/main/java/bvvpg/source/converters/GammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/GammaConverterSetup.java
@@ -59,7 +59,7 @@ public interface GammaConverterSetup extends ConverterSetup {
 	// lookup tables
 	String getLUTName();
 	
-	void setLUT(IndexColorModel icm_, String sLUTName);
+	void setLUT(final IndexColorModel icm_, String sLUTName);
 	
 	void setLUT(String sLUTName);
 	
@@ -76,15 +76,15 @@ public interface GammaConverterSetup extends ConverterSetup {
 	//clipping
 	boolean clipActive();
 	
-	void setClipInterval(RealInterval clipInt);
+	void setClipInterval(final RealInterval clipInt);
 	
 	void setClipActive(boolean bEnabled);
 	
 	FinalRealInterval getClipInterval();
 	
-	AffineTransform3D getClipTransform();
+	void getClipTransform(final AffineTransform3D t);
 	
-	void setClipTransform(AffineTransform3D t);	
+	void setClipTransform(final AffineTransform3D t);	
 	
 	//render style
 	void setRenderType(int nRender);

--- a/src/main/java/bvvpg/source/converters/GammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/GammaConverterSetup.java
@@ -73,7 +73,7 @@ public interface GammaConverterSetup extends ConverterSetup {
 	
 	public int getLUTSize();
 	
-	//clipping
+	/** whether the source's clipping is active **/
 	boolean clipActive();
 	
 	void setClipInterval(final RealInterval clipInt);
@@ -86,14 +86,16 @@ public interface GammaConverterSetup extends ConverterSetup {
 	
 	void setClipTransform(final AffineTransform3D t);	
 	
-	//render style
+	/** 0 = maximum intensity projection; 1 = "volumetric" **/
 	void setRenderType(int nRender);
 	
+	/** 0 = maximum intensity projection; 1 = "volumetric" **/
 	int getRenderType ();
 	
-	// voxel interpolation
+	/** 0 = nearest neighbor (cubes); 1 = tri-linear **/
 	void setVoxelRenderInterpolation(int nInterpolation);
 	
+	/** 0 = nearest neighbor (cubes); 1 = tri-linear **/
 	int getVoxelRenderInterpolation();
 	
 }

--- a/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
@@ -293,6 +293,7 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 		
 		listeners.list.forEach( l -> l.setupParametersChanged( this ) );
 	}
+	
 	@Override
 	public void setLUT(String sLUTName)
 	{
@@ -347,7 +348,17 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 		
 		return clipActive;
 	}
-
+	
+	@Override
+	public void setClipActive(boolean bEnabled)
+	{
+		if(clipActive != bEnabled )
+		{
+			clipActive = bEnabled;
+			listeners.list.forEach( l -> l.setupParametersChanged( this ) );
+		}
+	}
+	
 	@Override
 	public void setClipInterval(RealInterval clipInt) {
 		this.clipInt = new FinalRealInterval(clipInt);

--- a/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
@@ -407,7 +407,6 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 	{
 		texLUT = lut_;	
 		bUpdateTexture = false;
-		listeners.list.forEach( l -> l.setupParametersChanged( this ) );
 	}
 
 	@Override

--- a/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
@@ -327,8 +327,11 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 		if (nRender >2 || nRender <0)
 			nRenderType = 0;
 		else
-			nRenderType = nRender;
-		listeners.list.forEach( l -> l.setupParametersChanged( this ) );
+			if(nRenderType != nRender)
+			{
+				nRenderType = nRender;
+				listeners.list.forEach( l -> l.setupParametersChanged( this ) );
+			}
 	}
 
 	@Override
@@ -360,7 +363,8 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 	}
 	
 	@Override
-	public void setClipInterval(final RealInterval clipInt) {
+	public void setClipInterval(final RealInterval clipInt) 
+	{
 		this.clipInt = new FinalRealInterval(clipInt);
 		clipActive = true;
 		listeners.list.forEach( l -> l.setupParametersChanged( this ) );
@@ -403,12 +407,17 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 	{
 		texLUT = lut_;	
 		bUpdateTexture = false;
+		listeners.list.forEach( l -> l.setupParametersChanged( this ) );
 	}
 
 	@Override
 	public void setVoxelRenderInterpolation( int nInterpolation )
 	{
-		nVoxelInterpolation = nInterpolation;		
+		if(nVoxelInterpolation != nInterpolation)
+		{
+			nVoxelInterpolation = nInterpolation;	
+			listeners.list.forEach( l -> l.setupParametersChanged( this ) );
+		}
 	}
 
 	@Override

--- a/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
@@ -360,7 +360,7 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 	}
 	
 	@Override
-	public void setClipInterval(RealInterval clipInt) {
+	public void setClipInterval(final RealInterval clipInt) {
 		this.clipInt = new FinalRealInterval(clipInt);
 		clipActive = true;
 		listeners.list.forEach( l -> l.setupParametersChanged( this ) );
@@ -373,15 +373,20 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 	}
 
 	@Override
-	public AffineTransform3D getClipTransform() {
+	public void getClipTransform(final AffineTransform3D t) 
+	{
+		//we need to inverse it before return
+		t.set( clipTransform.inverse());
 		
-		return clipTransform;
+		return;
 	}
 
 	@Override
-	public void setClipTransform(AffineTransform3D t) {
-		
-		clipTransform = t.copy();
+	public void setClipTransform(final AffineTransform3D t) 
+	{
+		//since we apply transform to the coordinate,
+		//but not the bounding box, we need to store inverse
+		clipTransform.set( t.inverse());
 		listeners.list.forEach( l -> l.setupParametersChanged( this ) );
 	}
 

--- a/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
@@ -367,10 +367,9 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 	}
 
 	@Override
-	public FinalRealInterval getClipInterval() {
-		if(clipActive)
-			return clipInt;
-		return null;
+	public FinalRealInterval getClipInterval() 
+	{
+		return clipInt;
 	}
 
 	@Override

--- a/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
@@ -382,7 +382,7 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 	public void setClipTransform(AffineTransform3D t) {
 		
 		clipTransform = t.copy();
-		
+		listeners.list.forEach( l -> l.setupParametersChanged( this ) );
 	}
 
 	@Override

--- a/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
+++ b/src/main/java/bvvpg/source/converters/RealARGBColorGammaConverterSetup.java
@@ -374,19 +374,15 @@ public class RealARGBColorGammaConverterSetup implements GammaConverterSetup
 
 	@Override
 	public void getClipTransform(final AffineTransform3D t) 
-	{
-		//we need to inverse it before return
-		t.set( clipTransform.inverse());
-		
+	{	
+		t.set( clipTransform );			
 		return;
 	}
 
 	@Override
 	public void setClipTransform(final AffineTransform3D t) 
 	{
-		//since we apply transform to the coordinate,
-		//but not the bounding box, we need to store inverse
-		clipTransform.set( t.inverse());
+		clipTransform.set( t );
 		listeners.list.forEach( l -> l.setupParametersChanged( this ) );
 	}
 

--- a/src/main/java/bvvpg/ui/panels/BoundedRangePanelPG.java
+++ b/src/main/java/bvvpg/ui/panels/BoundedRangePanelPG.java
@@ -189,6 +189,11 @@ public class BoundedRangePanelPG extends JPanel
 		if ( upperBoundLabel != null )
 			updateBoundLabelFonts();
 	}
+	
+	public void setSliderForeground(final Color fg)
+	{
+		rangeSlider.setForeground( fg );
+	}
 
 	private void updateColors()
 	{

--- a/src/main/java/bvvpg/ui/panels/BoundedRangePanelPG.java
+++ b/src/main/java/bvvpg/ui/panels/BoundedRangePanelPG.java
@@ -72,7 +72,7 @@ import bvvpg.ui.sliders.RangeSliderPG;
  * @author Tobias Pietzsch
  * @author Eugene Katrukha
  */
-class BoundedRangePanelPG extends JPanel
+public class BoundedRangePanelPG extends JPanel
 {
 	private Supplier< JPopupMenu > popup;
 

--- a/src/main/java/bvvpg/ui/panels/BoundedValuePanelPG.java
+++ b/src/main/java/bvvpg/ui/panels/BoundedValuePanelPG.java
@@ -125,6 +125,7 @@ public class BoundedValuePanelPG extends JPanel {
 		//maxSpinner = new JSpinner( new SpinnerNumberModel( 1.0, 0.0, 1.0, 1.0 ) );
 		//slider = new ValueSlider( 0, SLIDER_LENGTH );
 		slider = new ValueSlider( 0, SLIDER_LENGTH );
+	
 		upperBoundLabel = new JLabel();
 		lowerBoundLabel = new JLabel();
 
@@ -171,6 +172,11 @@ public class BoundedValuePanelPG extends JPanel {
 		}
 		if ( upperBoundLabel != null )
 			updateBoundLabelFonts();
+	}
+	
+	public void setSliderForeground(final Color fg)
+	{
+		slider.setForeground( fg );
 	}
 
 	private void updateColors()

--- a/src/main/java/bvvpg/ui/sliders/RangeSliderUIFL.java
+++ b/src/main/java/bvvpg/ui/sliders/RangeSliderUIFL.java
@@ -755,6 +755,7 @@ class RangeSliderUIFL extends FlatSliderUI
 	
 
 		}
+		/** double click**/
 		@Override
 		public void mouseClicked(MouseEvent e) 
 		{
@@ -771,8 +772,8 @@ class RangeSliderUIFL extends FlatSliderUI
 					slider_.setUpperValue( slider_.getMaximum() );
 					return;
 				}
-				Rectangle mid = getMiddleTrackRectangle();
-				if(mid.contains( currentMouseX, currentMouseY ))
+				//Rectangle mid = getMiddleTrackRectangle();
+				if(trackRect.contains( currentMouseX, currentMouseY ))
 				{
 					slider_.setRange( slider_.getMinimum(), slider.getMaximum()  );
 				}

--- a/src/main/java/bvvpg/ui/sliders/RangeSliderUIPlain.java
+++ b/src/main/java/bvvpg/ui/sliders/RangeSliderUIPlain.java
@@ -817,8 +817,8 @@ class RangeSliderUIPlain extends BasicSliderUI
 					slider_.setUpperValue( slider_.getMaximum() );
 					return;
 				}
-				Rectangle mid = getMiddleTrackRectangle();
-				if(mid.contains( currentMouseX, currentMouseY ))
+				//Rectangle mid = getMiddleTrackRectangle();
+				if(trackRect.contains( currentMouseX, currentMouseY ))
 				{
 					slider_.setRange( slider_.getMinimum(), slider.getMaximum()  );
 				}

--- a/src/main/resources/bvvpg/core/render/sample_volume_blocks.frag
+++ b/src/main/resources/bvvpg/core/render/sample_volume_blocks.frag
@@ -25,7 +25,11 @@ uniform vec3 lutOffset;
 
 float sampleVolume( vec4 wpos, sampler3D volumeCache, vec3 cacheSize, vec3 blockSize, vec3 paddedBlockSize, vec3 padOffset )
 {
-	vec3 pos = (im * wpos).xyz + 0.5;
+	vec3 pos = (im * wpos).xyz;
+	//vec3 factor = step(0.0, (-1.0)*pos);
+	vec3 over = pos * step(0.0,pos) - pos;
+	pos = over + pos;
+	float zerofade = 1.0 - 2.0*max(over.x,max(over.y,over.z));
 	
 	if(clipactive>0)
 	{		
@@ -43,10 +47,11 @@ float sampleVolume( vec4 wpos, sampler3D volumeCache, vec3 cacheSize, vec3 block
 	pos = pos*sj;
 	if(voxelInterpolation == 0)
 	{
-		pos = floor(pos);
+		pos = floor(pos + 0.5);
+		zerofade = 1.0;
 	}
-	vec3 c0 = B0 + mod( pos, blockSize ) + 0.5 * sj;
+	vec3 c0 = B0 + mod( pos, blockSize ) + 0.5 * sj ;
 	                                       // + 0.5 ( sj - 1 )   + 0.5 for tex coord offset
 	
-	return texture( volumeCache, c0 / cacheSize ).r;
+	return zerofade*texture( volumeCache, c0 / cacheSize ).r;
 }

--- a/src/main/resources/bvvpg/core/render/sample_volume_blocks.frag
+++ b/src/main/resources/bvvpg/core/render/sample_volume_blocks.frag
@@ -13,16 +13,16 @@ void intersectBoundingBox( vec4 wfront, vec4 wback, out float tnear, out float t
 {
 	vec4 mfront = im * wfront;
 	vec4 mback = im * wback;	
-	if(clipactive>0)
-	{
-		vec3 rangemin = max(vec3((im*vec4(clipmin,1.0)).xyz), sourcemin - 0.5);
-		vec3 rangemax = min(vec3((im*vec4(clipmax,1.0)).xyz), sourcemax + 0.5);
-		intersectBox( mfront.xyz, (mback - mfront).xyz, rangemin, rangemax, tnear, tfar );
-	}
-	else
-	{
+//	if(clipactive>0)
+//	{
+//		vec3 rangemin = max(vec3((im*vec4(clipmin,1.0)).xyz), sourcemin - 0.5);
+//		vec3 rangemax = min(vec3((im*vec4(clipmax,1.0)).xyz), sourcemax + 0.5);
+//		intersectBox( mfront.xyz, (mback - mfront).xyz, rangemin, rangemax, tnear, tfar );
+//	}
+//	else
+//	{
 		intersectBox( mfront.xyz, (mback - mfront).xyz, sourcemin - 0.5, sourcemax + 0.5, tnear, tfar );
-	}
+//	}
 }
 
 
@@ -41,8 +41,14 @@ float sampleVolume( vec4 wpos, sampler3D volumeCache, vec3 cacheSize, vec3 block
 		//vec3 posclip = (cliptransform*vec4(pos-0.5,1.0)).xyz;
 		//vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
 		//vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
+		//vec3 cmin = (cliptransform*vec4(clipmin,1.0)).xyz;
+		//vec3 cmax = (cliptransform*vec4(clipmax,1.0)).xyz;
+		//vec3 posclip = wpos.xyz;
 		//vec3 s = step(cmin, posclip) - step(cmax, posclip);
-		vec3 s = step(clipmin, wpos.xyz) - step(clipmax, wpos.xyz);
+		
+		vec3 posclip = (cliptransform*wpos).xyz;
+		//vec3 s = step(cmin, posclip) - step(cmax, posclip);
+		vec3 s = step(clipmin, posclip) - step(clipmax, posclip);
 			
 		if(s.x * s.y * s.z==0.0)
 			return 0.0;

--- a/src/main/resources/bvvpg/core/render/sample_volume_blocks.frag
+++ b/src/main/resources/bvvpg/core/render/sample_volume_blocks.frag
@@ -13,16 +13,8 @@ void intersectBoundingBox( vec4 wfront, vec4 wback, out float tnear, out float t
 {
 	vec4 mfront = im * wfront;
 	vec4 mback = im * wback;	
-//	if(clipactive>0)
-//	{
-//		vec3 rangemin = max(vec3((im*vec4(clipmin,1.0)).xyz), sourcemin - 0.5);
-//		vec3 rangemax = min(vec3((im*vec4(clipmax,1.0)).xyz), sourcemax + 0.5);
-//		intersectBox( mfront.xyz, (mback - mfront).xyz, rangemin, rangemax, tnear, tfar );
-//	}
-//	else
-//	{
-		intersectBox( mfront.xyz, (mback - mfront).xyz, sourcemin - 0.5, sourcemax + 0.5, tnear, tfar );
-//	}
+
+	intersectBox( mfront.xyz, (mback - mfront).xyz, sourcemin - 0.5, sourcemax + 0.5, tnear, tfar );
 }
 
 
@@ -36,18 +28,8 @@ float sampleVolume( vec4 wpos, sampler3D volumeCache, vec3 cacheSize, vec3 block
 	vec3 pos = (im * wpos).xyz + 0.5;
 	
 	if(clipactive>0)
-	{
-		//mat4 temp = cliptransform*im;
-		//vec3 posclip = (cliptransform*vec4(pos-0.5,1.0)).xyz;
-		//vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
-		//vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
-		//vec3 cmin = (cliptransform*vec4(clipmin,1.0)).xyz;
-		//vec3 cmax = (cliptransform*vec4(clipmax,1.0)).xyz;
-		//vec3 posclip = wpos.xyz;
-		//vec3 s = step(cmin, posclip) - step(cmax, posclip);
-		
+	{		
 		vec3 posclip = (cliptransform*wpos).xyz;
-		//vec3 s = step(cmin, posclip) - step(cmax, posclip);
 		vec3 s = step(clipmin, posclip) - step(clipmax, posclip);
 			
 		if(s.x * s.y * s.z==0.0)

--- a/src/main/resources/bvvpg/core/render/sample_volume_blocks.frag
+++ b/src/main/resources/bvvpg/core/render/sample_volume_blocks.frag
@@ -15,13 +15,13 @@ void intersectBoundingBox( vec4 wfront, vec4 wback, out float tnear, out float t
 	vec4 mback = im * wback;	
 	if(clipactive>0)
 	{
-		vec3 rangemin = vec3((im*vec4(clipmin,1.0)).xyz);
-		vec3 rangemax = vec3((im*vec4(clipmax,1.0)).xyz);
+		vec3 rangemin = max(vec3((im*vec4(clipmin,1.0)).xyz), sourcemin - 0.5);
+		vec3 rangemax = min(vec3((im*vec4(clipmax,1.0)).xyz), sourcemax + 0.5);
 		intersectBox( mfront.xyz, (mback - mfront).xyz, rangemin, rangemax, tnear, tfar );
 	}
 	else
 	{
-		intersectBox( mfront.xyz, (mback - mfront).xyz, vec3( 0, 0, 0 ), sourcemax, tnear, tfar );
+		intersectBox( mfront.xyz, (mback - mfront).xyz, sourcemin - 0.5, sourcemax + 0.5, tnear, tfar );
 	}
 }
 
@@ -37,15 +37,13 @@ float sampleVolume( vec4 wpos, sampler3D volumeCache, vec3 cacheSize, vec3 block
 	
 	if(clipactive>0)
 	{
-		mat4 temp = cliptransform*im;
-		vec3 posclip = (cliptransform*vec4(pos-0.5,1.0)).xyz;
-		vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
-		vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
-		vec3 s = step(cmin, posclip) - step(cmax, posclip);
-		//vec3 posclip = pos - 0.5;
-		//vec3 s = step((im*vec4(clipmin,0.0)).xyz, posclip) - step((im*vec4(clipmax,0.0)).xyz, posclip);	
-		//vec3 posclip = wpos.xyz;
-		//vec3 s = step(clipmin, posclip) - step(clipmax, posclip);			
+		//mat4 temp = cliptransform*im;
+		//vec3 posclip = (cliptransform*vec4(pos-0.5,1.0)).xyz;
+		//vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
+		//vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
+		//vec3 s = step(cmin, posclip) - step(cmax, posclip);
+		vec3 s = step(clipmin, wpos.xyz) - step(clipmax, wpos.xyz);
+			
 		if(s.x * s.y * s.z==0.0)
 			return 0.0;
 	} 

--- a/src/main/resources/bvvpg/core/render/sample_volume_simple.frag
+++ b/src/main/resources/bvvpg/core/render/sample_volume_simple.frag
@@ -10,16 +10,8 @@ void intersectBoundingBox( vec4 wfront, vec4 wback, out float tnear, out float t
 {
 	vec4 mfront = im * wfront;
 	vec4 mback = im * wback;	
-	if(clipactive>0)
-	{
-		vec3 rangemin = max(vec3((im*vec4(clipmin,1.0)).xyz), vec3( -0.5, -0.5, -0.5 ));
-		vec3 rangemax = min(vec3((im*vec4(clipmax,1.0)).xyz), sourcemax + 0.5);
-		intersectBox( mfront.xyz, (mback - mfront).xyz, rangemin, rangemax, tnear, tfar );
-	}
-	else
-	{
-		intersectBox( mfront.xyz, (mback - mfront).xyz, vec3( -0.5, -0.5, -0.5 ), sourcemax + 0.5, tnear, tfar );
-	}
+
+	intersectBox( mfront.xyz, (mback - mfront).xyz, vec3( -0.5, -0.5, -0.5 ), sourcemax + 0.5, tnear, tfar );
 }
 
 uniform sampler3D volume;
@@ -30,14 +22,9 @@ float sampleVolume( vec4 wpos )
 	
 	if(clipactive>0)
 	{
-		//apply clip transform
-		mat4 temp = cliptransform*im;
-		//vec3 posclip = (cliptransform*vec4(pos,1.0)).xyz;
-		//vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
-		//vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
-		//vec3 s = step(cmin, posclip) - step(cmax, posclip);
-		vec3 posclip = wpos.xyz;
+		vec3 posclip = (cliptransform*wpos).xyz;
 		vec3 s = step(clipmin, posclip) - step(clipmax, posclip);
+			
 		if(s.x * s.y * s.z==0.0)
 			return 0.0;
 	} 

--- a/src/main/resources/bvvpg/core/render/sample_volume_simple.frag
+++ b/src/main/resources/bvvpg/core/render/sample_volume_simple.frag
@@ -12,13 +12,13 @@ void intersectBoundingBox( vec4 wfront, vec4 wback, out float tnear, out float t
 	vec4 mback = im * wback;	
 	if(clipactive>0)
 	{
-		vec3 rangemin = vec3((im*vec4(clipmin,1.0)).xyz);
-		vec3 rangemax = vec3((im*vec4(clipmax,1.0)).xyz);
+		vec3 rangemin = max(vec3((im*vec4(clipmin,1.0)).xyz), vec3( -0.5, -0.5, -0.5 ));
+		vec3 rangemax = min(vec3((im*vec4(clipmax,1.0)).xyz), sourcemax + 0.5);
 		intersectBox( mfront.xyz, (mback - mfront).xyz, rangemin, rangemax, tnear, tfar );
 	}
 	else
 	{
-		intersectBox( mfront.xyz, (mback - mfront).xyz, vec3( 0, 0, 0 ), sourcemax, tnear, tfar );
+		intersectBox( mfront.xyz, (mback - mfront).xyz, vec3( -0.5, -0.5, -0.5 ), sourcemax + 0.5, tnear, tfar );
 	}
 }
 
@@ -26,24 +26,24 @@ uniform sampler3D volume;
 
 float sampleVolume( vec4 wpos )
 {
-	vec3 pos = (im * wpos).xyz;
+	vec3 pos = (im * wpos).xyz + 0.5;
 	
 	if(clipactive>0)
 	{
 		//apply clip transform
 		mat4 temp = cliptransform*im;
-		vec3 posclip = (cliptransform*vec4(pos,1.0)).xyz;
-		vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
-		vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
-		vec3 s = step(cmin, posclip) - step(cmax, posclip);
-		//vec3 posclip = wpos.xyz;
-		//vec3 s = step(clipmin, posclip) - step(clipmax, posclip);
+		//vec3 posclip = (cliptransform*vec4(pos,1.0)).xyz;
+		//vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
+		//vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
+		//vec3 s = step(cmin, posclip) - step(cmax, posclip);
+		vec3 posclip = wpos.xyz;
+		vec3 s = step(clipmin, posclip) - step(clipmax, posclip);
 		if(s.x * s.y * s.z==0.0)
 			return 0.0;
 	} 
 	if(voxelInterpolation == 0)
 	{
-		pos = floor(pos);
+		pos = floor(pos) + 0.5;
 	}
-	return texture( volume, (pos+0.5) / textureSize( volume, 0 ) ).r;
+	return texture( volume, pos / textureSize( volume, 0 ) ).r;
 }

--- a/src/main/resources/bvvpg/core/render/sample_volume_simple_rgba.frag
+++ b/src/main/resources/bvvpg/core/render/sample_volume_simple_rgba.frag
@@ -12,13 +12,13 @@ void intersectBoundingBox( vec4 wfront, vec4 wback, out float tnear, out float t
 	vec4 mback = im * wback;	
 	if(clipactive>0)
 	{
-		vec3 rangemin = vec3((im*vec4(clipmin,1.0)).xyz);
-		vec3 rangemax = vec3((im*vec4(clipmax,1.0)).xyz);
+		vec3 rangemin = max(vec3((im*vec4(clipmin,1.0)).xyz), vec3( -0.5, -0.5, -0.5 ));
+		vec3 rangemax = min(vec3((im*vec4(clipmax,1.0)).xyz), sourcemax + 0.5);
 		intersectBox( mfront.xyz, (mback - mfront).xyz, rangemin, rangemax, tnear, tfar );
 	}
 	else
 	{
-		intersectBox( mfront.xyz, (mback - mfront).xyz, vec3( 0, 0, 0 ), sourcemax, tnear, tfar );
+		intersectBox( mfront.xyz, (mback - mfront).xyz,  vec3( -0.5, -0.5, -0.5 ), sourcemax + 0.5, tnear, tfar );
 	}
 }
 
@@ -26,24 +26,24 @@ uniform sampler3D volume;
 
 vec4 sampleVolume( vec4 wpos )
 {
-	vec3 pos = (im * wpos).xyz;
+	vec3 pos = (im * wpos).xyz + 0.5;
 	
 	if(clipactive>0)
 	{
 		//apply clip transform
-		mat4 temp = cliptransform*im;
-		vec3 posclip = (cliptransform*vec4(pos,1.0)).xyz;
-		vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
-		vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
-		vec3 s = step(cmin, posclip) - step(cmax, posclip);
+		//mat4 temp = cliptransform*im;
+		//vec3 posclip = (cliptransform*vec4(pos,1.0)).xyz;
+		//vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
+		//vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
+		//vec3 s = step(cmin, posclip) - step(cmax, posclip);
 		//vec3 posclip = wpos.xyz;
-		//vec3 s = step(clipmin, posclip) - step(clipmax, posclip);
+		vec3 s = step(clipmin, wpos) - step(clipmax, wpos);
 		if(s.x * s.y * s.z==0.0)
 			return vec4(0.0,0.0,0.0,0.0);
 	} 
 	if(voxelInterpolation == 0)
 	{
-		pos = floor(pos);
+		pos = floor(pos) + 0.5;
 	}
-	return texture( volume, (pos+0.5) / textureSize( volume, 0 ) );
+	return texture( volume, pos / textureSize( volume, 0 ) );
 }

--- a/src/main/resources/bvvpg/core/render/sample_volume_simple_rgba.frag
+++ b/src/main/resources/bvvpg/core/render/sample_volume_simple_rgba.frag
@@ -9,17 +9,9 @@ uniform mat4 cliptransform;
 void intersectBoundingBox( vec4 wfront, vec4 wback, out float tnear, out float tfar )
 {
 	vec4 mfront = im * wfront;
-	vec4 mback = im * wback;	
-	if(clipactive>0)
-	{
-		vec3 rangemin = max(vec3((im*vec4(clipmin,1.0)).xyz), vec3( -0.5, -0.5, -0.5 ));
-		vec3 rangemax = min(vec3((im*vec4(clipmax,1.0)).xyz), sourcemax + 0.5);
-		intersectBox( mfront.xyz, (mback - mfront).xyz, rangemin, rangemax, tnear, tfar );
-	}
-	else
-	{
-		intersectBox( mfront.xyz, (mback - mfront).xyz,  vec3( -0.5, -0.5, -0.5 ), sourcemax + 0.5, tnear, tfar );
-	}
+	vec4 mback = im * wback;
+
+	intersectBox( mfront.xyz, (mback - mfront).xyz,  vec3( -0.5, -0.5, -0.5 ), sourcemax + 0.5, tnear, tfar );
 }
 
 uniform sampler3D volume;
@@ -30,14 +22,9 @@ vec4 sampleVolume( vec4 wpos )
 	
 	if(clipactive>0)
 	{
-		//apply clip transform
-		//mat4 temp = cliptransform*im;
-		//vec3 posclip = (cliptransform*vec4(pos,1.0)).xyz;
-		//vec3 cmin = (temp*vec4(clipmin,1.0)).xyz;
-		//vec3 cmax = (temp*vec4(clipmax,1.0)).xyz;
-		//vec3 s = step(cmin, posclip) - step(cmax, posclip);
-		//vec3 posclip = wpos.xyz;
-		vec3 s = step(clipmin, wpos) - step(clipmax, wpos);
+		vec3 posclip = (cliptransform*wpos).xyz;
+		vec3 s = step(clipmin, posclip) - step(clipmax, posclip);
+			
 		if(s.x * s.y * s.z==0.0)
 			return vec4(0.0,0.0,0.0,0.0);
 	} 

--- a/src/test/java/bvvpg/debug/DebugClipInterval.java
+++ b/src/test/java/bvvpg/debug/DebugClipInterval.java
@@ -1,0 +1,101 @@
+package bvvpg.debug;
+
+import java.awt.Dimension;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JFrame;
+
+import net.imglib2.FinalRealInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.view.Views;
+
+import org.fusesource.jansi.Ansi.Color;
+
+import bdv.spimdata.SpimDataMinimal;
+import bdv.spimdata.XmlIoSpimDataMinimal;
+import bdv.tools.transformation.TransformedSource;
+import bdv.util.BoundedValueDouble;
+import bdv.viewer.SourceAndConverter;
+import bvvpg.core.VolumeViewerPanel;
+import bvvpg.ui.panels.BoundedValuePanelPG;
+import bvvpg.vistools.Bvv;
+import bvvpg.vistools.BvvFunctions;
+import bvvpg.vistools.BvvSource;
+import bvvpg.vistools.BvvStackSource;
+import ij.IJ;
+import ij.ImagePlus;
+import mpicbg.spim.data.SpimDataException;
+
+public class DebugClipInterval
+{
+	public static void main( final String[] args )
+	{
+		
+		//regular tif init
+		/**/
+
+		final ImagePlus imp = IJ.openImage( "/home/eugene/Desktop/projects/BVB/cliptest.tif" );
+		final Img< UnsignedShortType > img = ImageJFunctions.wrapShort( imp );
+		ArrayList< BvvStackSource< ? >> sources =  new ArrayList<>();
+		
+		AffineTransform3D scaleAF = new AffineTransform3D();
+		scaleAF.scale( 3.0 );
+		
+		sources.add( BvvFunctions.show( Views.hyperSlice(img,2,0), "ch1",  Bvv.options().sourceTransform( scaleAF ) ));
+		sources.add( BvvFunctions.show( Views.hyperSlice(img,2,1), "ch2", Bvv.options().sourceTransform( scaleAF ).addTo( sources.get( 0 ).getBvvHandle() ) ));
+		
+		
+		
+//		final String xmlFilename = "/home/eugene/Desktop/projects/BVB/cliptest.xml";
+//		SpimDataMinimal spimData = null;
+//		try {
+//			spimData = new XmlIoSpimDataMinimal().load( xmlFilename );
+//		} catch (SpimDataException e) {
+//			e.printStackTrace();
+//		}		
+//		List< BvvStackSource< ? > > sources = BvvFunctions.show( spimData );
+		
+		
+		
+		sources.get( 0 ).setLUT( "Green" );
+		sources.get( 1 ).setLUT( "Red" );
+		sources.get( 0 ).setVoxelRenderInterpolation( 0 );
+		sources.get( 1 ).setVoxelRenderInterpolation( 0 );
+		double [] min = new double[3];
+		double [] max = new double[3];
+		//min[0]=0.1;
+		for (int d=0;d<3;d++)
+		{
+			max[d]= 100;
+		}
+		
+		sources.get( 1 ).setClipInterval( new FinalRealInterval(min,max) );
+		final VolumeViewerPanel panel = sources.get(0).getBvvHandle().getViewerPanel();
+		
+		JFrame frame = new JFrame("clip bound");
+		frame.setAlwaysOnTop( true );
+		frame.getContentPane().setPreferredSize( new Dimension(450,40) );
+		BoundedValueDouble model = new BoundedValueDouble( -1.0, 20.0, 0. );
+		BoundedValuePanelPG clipXPanel = new BoundedValuePanelPG(model);
+		clipXPanel.setConsistent( true );
+		
+		clipXPanel.changeListeners().add(new BoundedValuePanelPG.ChangeListener()
+		{
+
+			@Override
+			public void boundedValueChanged(  )
+			{
+				min[0]= clipXPanel.getValue().getCurrentValue();
+				sources.get( 1 ).setClipInterval( new FinalRealInterval(min,max) );
+				panel.requestRepaint();
+			}});
+
+		frame.getContentPane().add(clipXPanel);
+		frame.pack();
+		frame.setVisible(true);
+	}
+}

--- a/src/test/java/bvvpg/debug/DebugClipInterval.java
+++ b/src/test/java/bvvpg/debug/DebugClipInterval.java
@@ -1,10 +1,13 @@
 package bvvpg.debug;
 
+import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.KeyboardFocusManager;
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JFrame;
+import javax.swing.JTextField;
 
 import net.imglib2.FinalRealInterval;
 import net.imglib2.img.Img;
@@ -13,6 +16,8 @@ import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.view.Views;
 
+import org.scijava.ui.behaviour.io.InputTriggerConfig;
+import org.scijava.ui.behaviour.util.Actions;
 
 import bdv.spimdata.SpimDataMinimal;
 import bdv.spimdata.XmlIoSpimDataMinimal;
@@ -37,26 +42,26 @@ public class DebugClipInterval
 		//regular tif init
 		/**/
 
-		final ImagePlus imp = IJ.openImage( "/home/eugene/Desktop/projects/BVB/cliptest.tif" );
-		final Img< UnsignedShortType > img = ImageJFunctions.wrapShort( imp );
-		ArrayList< BvvStackSource< ? >> sources =  new ArrayList<>();
+//		final ImagePlus imp = IJ.openImage( "/home/eugene/Desktop/projects/BVB/cliptest.tif" );
+//		final Img< UnsignedShortType > img = ImageJFunctions.wrapShort( imp );
+//		ArrayList< BvvStackSource< ? >> sources =  new ArrayList<>();
+//		
+//		AffineTransform3D scaleAF = new AffineTransform3D();
+//		scaleAF.scale( 2.0 );
+//		
+//		sources.add( BvvFunctions.show( Views.hyperSlice(img,2,0), "ch1",  Bvv.options().sourceTransform( scaleAF ) ));
+//		sources.add( BvvFunctions.show( Views.hyperSlice(img,2,1), "ch2", Bvv.options().sourceTransform( scaleAF ).addTo( sources.get( 0 ).getBvvHandle() ) ));
 		
-		AffineTransform3D scaleAF = new AffineTransform3D();
-		scaleAF.scale( 3.0 );
-		
-		sources.add( BvvFunctions.show( Views.hyperSlice(img,2,0), "ch1",  Bvv.options().sourceTransform( scaleAF ) ));
-		sources.add( BvvFunctions.show( Views.hyperSlice(img,2,1), "ch2", Bvv.options().sourceTransform( scaleAF ).addTo( sources.get( 0 ).getBvvHandle() ) ));
 		
 		
-		
-//		final String xmlFilename = "/home/eugene/Desktop/projects/BVB/cliptest.xml";
-//		SpimDataMinimal spimData = null;
-//		try {
-//			spimData = new XmlIoSpimDataMinimal().load( xmlFilename );
-//		} catch (SpimDataException e) {
-//			e.printStackTrace();
-//		}		
-//		List< BvvStackSource< ? > > sources = BvvFunctions.show( spimData );
+		final String xmlFilename = "/home/eugene/Desktop/projects/BVB/cliptest.xml";
+		SpimDataMinimal spimData = null;
+		try {
+			spimData = new XmlIoSpimDataMinimal().load( xmlFilename );
+		} catch (SpimDataException e) {
+			e.printStackTrace();
+		}		
+		List< BvvStackSource< ? > > sources = BvvFunctions.show( spimData );
 		
 		
 		
@@ -71,17 +76,36 @@ public class DebugClipInterval
 		{
 			max[d]= 100;
 		}
+		min[0] = -100;
+		min[1] = -100;
+		min[2] = -100;
 		
-		sources.get( 1 ).setClipInterval( new FinalRealInterval(min,max) );
+		sources.get( 0 ).setClipInterval( new FinalRealInterval(min,max) );
 		final VolumeViewerPanel panel = sources.get(0).getBvvHandle().getViewerPanel();
+
+		final Actions actions = new Actions( new InputTriggerConfig() );
+		final int[] dD = new int [1];
+		dD[0] = 0;
+		actions.runnableAction(
+				() -> {
+					if(dD[0]==0)
+						dD[0] = 1;
+					else
+						dD[0] = 0;
+					sources.get( 0 ).setVoxelRenderInterpolation( dD[0] );
+				},
+				"change interp",
+				"D" );
+		
+		actions.install( sources.get(0).getBvvHandle().getKeybindings(), "BigTrace actions" );
 		
 		JFrame frame = new JFrame("clip bound");
 		frame.setAlwaysOnTop( true );
 		frame.getContentPane().setPreferredSize( new Dimension(450,40) );
-		BoundedValueDouble model = new BoundedValueDouble( -1.0, 20.0, 0. );
+		BoundedValueDouble model = new BoundedValueDouble( -3.0, 20.0, 0. );
 		BoundedValuePanelPG clipXPanel = new BoundedValuePanelPG(model);
 		clipXPanel.setConsistent( true );
-		
+
 		clipXPanel.changeListeners().add(new BoundedValuePanelPG.ChangeListener()
 		{
 
@@ -89,7 +113,7 @@ public class DebugClipInterval
 			public void boundedValueChanged(  )
 			{
 				min[0]= clipXPanel.getValue().getCurrentValue();
-				sources.get( 1 ).setClipInterval( new FinalRealInterval(min,max) );
+				sources.get( 0 ).setClipInterval( new FinalRealInterval(min,max) );
 				panel.requestRepaint();
 			}});
 

--- a/src/test/java/bvvpg/debug/DebugClipInterval.java
+++ b/src/test/java/bvvpg/debug/DebugClipInterval.java
@@ -13,7 +13,6 @@ import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.view.Views;
 
-import org.fusesource.jansi.Ansi.Color;
 
 import bdv.spimdata.SpimDataMinimal;
 import bdv.spimdata.XmlIoSpimDataMinimal;

--- a/src/test/java/bvvpg/debug/DebugClipTransform.java
+++ b/src/test/java/bvvpg/debug/DebugClipTransform.java
@@ -1,0 +1,47 @@
+package bvvpg.debug;
+
+import java.util.List;
+
+import net.imglib2.FinalRealInterval;
+import net.imglib2.realtransform.AffineTransform3D;
+
+import bdv.spimdata.SpimDataMinimal;
+import bdv.spimdata.XmlIoSpimDataMinimal;
+import bvvpg.vistools.BvvFunctions;
+import bvvpg.vistools.BvvStackSource;
+import bvvpg.source.converters.GammaConverterSetup;
+import mpicbg.spim.data.SpimDataException;
+
+public class DebugClipTransform
+{
+
+	public static void main( final String[] args )
+	{
+		final String xmlFilename = "/home/eugene/Desktop/projects/BVB/whitecube_2ch.xml";
+		SpimDataMinimal spimData = null;
+		try {
+			spimData = new XmlIoSpimDataMinimal().load( xmlFilename );
+		} catch (SpimDataException e) {
+			e.printStackTrace();
+		}		
+		List< BvvStackSource< ? > > sources = BvvFunctions.show( spimData );
+		
+		sources.get( 0 ).setLUT( "Green" );
+		sources.get( 1 ).setLUT( "Red" );
+		
+		double [][] mm = new double [2][3];
+		for (int d=0;d<3;d++)
+		{
+			mm[1][d] = 100;
+		}
+		AffineTransform3D tr = new AffineTransform3D();
+		double [] trans = new double [3];
+		trans[0] = 50;
+		tr.translate( trans);
+		System.out.println( tr );
+		sources.get( 0 ).setClipInterval( new FinalRealInterval(mm[0],mm[1]));
+		sources.get( 0 ).setClipTransform( tr );
+		((GammaConverterSetup)(sources.get( 0 ).getConverterSetups().get( 0 ))).getClipTransform(tr);
+		System.out.println( tr );
+	}
+}

--- a/updates_history.md
+++ b/updates_history.md
@@ -5,7 +5,7 @@
 - added orthographic projection rendering (>viewer->setProjectionType);
 - remade range and value (regular) sliders, no dependence on jide library;
 - sliders color can be changed, double click expands range slider;
-- clip interval is now in BVV world coordinated;
+- clip interval is now in BVV world coordinates;
 - clip transform is now "inverted" in shaders, i.e. can be treated as normal;
 - volume rendering now happens from -0.5 pixel width till (N-1)+0.5, where N is pixel number;
 - added "fake" linear interpolation for -0.5 till 0.0 rendering range in trilinear interpolation mode;

--- a/updates_history.md
+++ b/updates_history.md
@@ -1,0 +1,26 @@
+# Updates history
+
+## 0.4.0
+
+- added orthographic projection rendering (>viewer->setProjectionType);
+- remade range and value (regular) sliders, no dependence on jide library;
+- sliders color can be changed, double click expands range slider;
+- clip interval is now in BVV world coordinated;
+- clip transform is now "inverted" in shaders, i.e. can be treated as normal;
+- volume rendering now happens from -0.5 pixel width till (N-1)+0.5, where N is pixel number;
+- added "fake" linear interpolation for -0.5 till 0.0 rendering range in trilinear interpolation mode;
+- added exposed source selection listeners in the source table;
+- added function to select sources in source table from outside programmatically;
+
+## 0.3.4
+
+- updated to fiji POM 40.0.0;
+
+## 0.3.3
+
+- fixed thrown exception during BVV restart;
+
+----------
+Developed in <a href='http://cellbiology.science.uu.nl/'>Cell Biology group</a> of Utrecht University.  
+<a href="mailto:katpyxa@gmail.com">E-mail</a> for any questions or tag <a href="https://forum.image.sc/u/ekatrukha/summary">@ekatrukha</a> at <a href="https://forum.image.sc/">image.sc</a> forum.
+


### PR DESCRIPTION
What is new and changed

- added orthographic projection rendering (>viewer->setProjectionType);
- remade range and value (regular) sliders, no dependence on jide library;
- sliders color can be changed, double click expands range slider;
- clip interval is now in BVV world coordinates;
- clip transform is now "inverted" in shaders, i.e. can be treated as normal;
- volume rendering now happens from -0.5 pixel width till (N-1)+0.5, where N is pixel number;
- added "fake" linear interpolation for -0.5 till 0.0 rendering range in trilinear interpolation mode;
- added exposed source selection listeners in the source table;
- added function to select sources in source table from outside programmatically;