### PR TITLE
next release (0.5.5)

### DIFF
--- a/src/main/java/bvvpg/core/offscreen/OffScreenFrameBufferWithDepth.java
+++ b/src/main/java/bvvpg/core/offscreen/OffScreenFrameBufferWithDepth.java
@@ -410,8 +410,8 @@ public class OffScreenFrameBufferWithDepth
 		progQuadDepth.use( context );
 		gl.glActiveTexture( GL_TEXTURE0 );
 		gl.glBindTexture( GL_TEXTURE_2D, texDepthBuffer );
-		gl.glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
-		gl.glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+		gl.glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL.GL_NEAREST );
+		gl.glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL.GL_NEAREST );
 		gl.glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
 		gl.glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
 		gl.glBindVertexArray( vaoQuad );
@@ -484,13 +484,15 @@ public class OffScreenFrameBufferWithDepth
 		@Override
 		public MinFilter texMinFilter()
 		{
-			return MinFilter.LINEAR;
+			return MinFilter.NEAREST;
 		}
 
+		// changed to nearest due to interpolation artifacts
+		// of fine shapes
 		@Override
 		public MagFilter texMagFilter()
 		{
-			return MagFilter.LINEAR;
+			return MagFilter.NEAREST;
 		}
 
 		@Override

--- a/src/main/resources/bvvpg/core/dither/stitch.fp
+++ b/src/main/resources/bvvpg/core/dither/stitch.fp
@@ -8,7 +8,29 @@ uniform vec2 tls;
 
 void main()
 {
-	vec2 xg = trunc( ( gl_FragCoord.xy - 0.5 ) * viewportScale );
+	ivec2 pixel = ivec2(gl_FragCoord.xy);
+	
+	// grid coordinate
+	ivec2 xg = ivec2(gl_FragCoord.xy * viewportScale);
+	
+	// safe modulo
+	ivec2 spw_i = ivec2(spw);
+	
+	ivec2 o = ivec2(
+	    xg.x - (xg.x / spw_i.x) * spw_i.x,
+	    xg.y - (xg.y / spw_i.y) * spw_i.y
+	);
+	
+	// compute source texel
+	ivec2 q = (xg - o) / spw_i + o * ivec2(tls);
+	
+	//sample color and depth
+	FragColor = texelFetch(tex, q, 0);
+	gl_FragDepth = texelFetch(texDepth, q, 0).x;
+
+	////OLD VERSION
+	
+	//vec2 xg = trunc( ( gl_FragCoord.xy - 0.5 ) * viewportScale );
 	/*
 	    Something is slightly off with floor() and mod() on AMD GPUs,
 	    which causes floor(n*3/3) = n-1 and mod(n*3, 3) = 3 instead of
@@ -21,8 +43,9 @@ void main()
 	        trunc( mod( xg + 0.1, spw ) )
 	    below. (This works reliably because xg is always integral.)
 	*/
-	vec2 o = trunc( mod( xg + 0.1, spw ) );
-	vec2 q = ( xg - o ) / spw + o * tls + 0.5;
-	FragColor = texture( tex, q / textureSize( tex, 0 ) );
-	gl_FragDepth = texture( texDepth, q / textureSize( texDepth, 0 ) ).x ;
+
+	//vec2 o = trunc( mod( xg + 0.1, spw ) );
+	//vec2 q = ( xg - o ) / spw + o * tls + 0.5;
+	//FragColor = texture( tex, q / textureSize( tex, 0 ) );
+	//gl_FragDepth = texture( texDepth, q / textureSize( texDepth, 0 ) ).x ;
 }

--- a/updates_history.md
+++ b/updates_history.md
@@ -1,5 +1,10 @@
 # Updates history
 
+## 0.5.5
+
+- changes depth buffer interpolation from linear to nearest (fixes depth leakage);
+- fixes stitching of dithered rendering mode for depth and color. 
+
 ## 0.5.4
 
 - updates of LUT/alpha range sliders and both gamma sliders happens simultaneously;

--- a/updates_history.md
+++ b/updates_history.md
@@ -9,7 +9,8 @@
 
 - updates of LUT/alpha range sliders and both gamma sliders happens simultaneously;
 - stores the value of "sync" checkbox per converter setup + updates it on change;
-- possibility to change text overlay color (if canvas background color is not black). 
+- possibility to change text overlay color (if canvas background color is not black);
+- sync to BVV 0.4.2 version. 
 
 ## 0.5.3
 


### PR DESCRIPTION
1) changes depth buffer interpolation from linear to nearest (fixes depth leakage);
2) fixes stitching of dithered rendering mode for depth and color.
Illustration of the problem before:

https://github.com/user-attachments/assets/d1229d80-d32d-4f0a-9912-d6c57c87ba8a

Applying fix 1:

https://github.com/user-attachments/assets/9486853f-2528-4b76-92e9-06f69e2fb541

Applying fix 2:

https://github.com/user-attachments/assets/704bc3bc-f785-4532-b3bf-aeeee138072e

