### PR TITLE
Handle generic CacheControl in spimdata loading

### DIFF
--- a/src/main/java/bvvpg/vistools/BvvFunctions.java
+++ b/src/main/java/bvvpg/vistools/BvvFunctions.java
@@ -30,6 +30,7 @@ package bvvpg.vistools;
 
 import bdv.BigDataViewer;
 import bdv.ViewerImgLoader;
+import bdv.cache.CacheControl;
 import bdv.img.cache.VolatileGlobalCellCache;
 import bdv.spimdata.WrapBasicImgLoader;
 import bdv.tools.brightness.ConverterSetup;
@@ -191,9 +192,10 @@ public class BvvFunctions
 		final BvvHandle handle = getHandle( options );
 		final AbstractSequenceDescription< ?, ?, ? > seq = spimData.getSequenceDescription();
 		final int numTimepoints = seq.getTimePoints().size();
-		final VolatileGlobalCellCache cache = ( VolatileGlobalCellCache ) ( ( ViewerImgLoader ) seq.getImgLoader() ).getCacheControl();
+		final CacheControl cache = ( ( ViewerImgLoader ) seq.getImgLoader() ).getCacheControl();
 		handle.getBvvHandle().getCacheControls().addCacheControl( cache );
-		cache.clearCache();
+		if ( cache instanceof VolatileGlobalCellCache )
+			( ( VolatileGlobalCellCache ) cache ).clearCache();
 
 		WrapBasicImgLoader.wrapImgLoaderIfNecessary( spimData );
 		final ArrayList< SourceAndConverter< ? > > sources = new ArrayList<>();

--- a/src/test/java/bvvpg/debug/DebugLargeLUT.java
+++ b/src/test/java/bvvpg/debug/DebugLargeLUT.java
@@ -106,7 +106,7 @@ public class DebugLargeLUT
 		colors[0][0] = ( byte ) 0;
 		colors[1][0] = ( byte )  0 ;
 		colors[2][0] = ( byte ) 255 ;
-		for(int i=1;i<nTotLength;i++)
+		for(int i = 1; i < nTotLength; i++)
 		{
 			int nStep = (int) Math.round( 255.0*i/(nTotLength));
 			colors[0][i] = ( byte ) nStep ;
@@ -129,7 +129,7 @@ public class DebugLargeLUT
 		colors[2][0] = ( byte ) 255 ;
 		colors[3][0] = ( byte ) 255 ;
 		
-		for(int i=1;i<nTotLength;i++)
+		for(int i = 1; i < nTotLength; i++)
 		{
 			int nStep = (int) Math.round( 255.0*i/(nTotLength));
 			colors[0][i] = ( byte ) nStep ;

--- a/updates_history.md
+++ b/updates_history.md
@@ -1,5 +1,11 @@
 # Updates history
 
+
+## 0.5.6
+
+- removes the assumption that ViewerImgLoader#getCacheControl() of SpimData always returns a
+VolatileGlobalCellCache.
+
 ## 0.5.5
 
 - changes depth buffer interpolation from linear to nearest (fixes depth leakage);


### PR DESCRIPTION
This change removes the assumption that `ViewerImgLoader#getCacheControl()` of `SpimData` always returns a
`VolatileGlobalCellCache`.

Previously, the code performed an unconditional cast in order to register the cache control and clear the cache. This could fail for imgloaders returning a different `CacheControl` implementation.

The updated version:
- works with the generic `CacheControl` interface when registering
  cache controls
- only calls `clearCache()` when the implementation is actually a
  `VolatileGlobalCellCache`

Basically, the same way [it is done in BDV](https://github.com/bigdataviewer/bigdataviewer-core/blob/b64d414cd3bdd7949f72e1c26363738464124fba/src/main/java/bdv/util/BdvFunctions.java#L328).